### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Build artifact
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: ">=1.19.0"
+      
+      - name: Display Go version
+        run: |
+          go version
 
       - name: Build artifact
         run: |

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -19,7 +19,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Songmu/tagpr@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release 作成時のArtiface アップデート用Actionにおいて setup-go が失敗している。
よくみると、 `go v1.2` をダウンロードしているように見える…
https://github.com/sota0121/dotfiles/actions/runs/6596884355